### PR TITLE
Fix underlying network changed error

### DIFF
--- a/src/utils/library.ts
+++ b/src/utils/library.ts
@@ -2,14 +2,7 @@ import { Web3Provider } from '@ethersproject/providers'
 import { NETWORK_POLLING_INTERVALS } from 'constants/misc'
 
 export function getLibrary(provider: any): Web3Provider {
-  const library = new Web3Provider(
-    provider,
-    typeof provider.chainId === 'number'
-      ? provider.chainId
-      : typeof provider.chainId === 'string'
-      ? parseInt(provider.chainId)
-      : 'any'
-  )
+  const library = new Web3Provider(provider, 'any')
   library.pollingInterval = 15000
   library.detectNetwork().then((network) => {
     const networkPollingInterval = NETWORK_POLLING_INTERVALS[network.chainId]


### PR DESCRIPTION
This is related to a bug that when you enter a page like `https://app.dei.finance/vest`, it will not fetch the data and the console shows an error `Error: underlying network changed`.

Steps to reproduce:
1. open a fresh new tab and directly go to `https://app.dei.finance/vest`
2. even if you have veDEUS, it says `No Results Found` on the page
3. refresh the page and the result shows now

Reason for the bug:
It appears that the `chainId` changed from `0x1` to `0xfa` when first entering the page (therefore step 1 requires you to have a fresh new tab). When the underlying `chainId` changes, the `getLibrary` function will fail. However, if you refresh the page, the `chainId` will stay `0xfa` which will be correct and it can now fetch the data correctly.

Related issue:
https://github.com/ethers-io/ethers.js/issues/866

Remarks:
The above issue says `any` will work and I tested it does fix the issue. However, I am not sure about the intention of the original code and am not sure if it will affect other functionality of the app. Please be careful when you merge this code, thank you!